### PR TITLE
feat(workflow): add support for debug and release builds

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -14,16 +14,15 @@ env:
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
       with: 
         submodules: true
+
     - uses: actions/cache@v3
+
     - uses: lukka/get-cmake@latest
 
     - name: Bootstrap vcpkg
@@ -33,9 +32,9 @@ jobs:
     - name: Run CMake consuming CMakePreset.json and run vcpkg to build packages
       uses: lukka/run-cmake@v10
       with:
-        configurePreset: 'vcpkg'
-        buildPreset: 'default'
+        configurePreset: 'vcpkg-release'
+        buildPreset: 'release'
 
     - name: Run latest
-      run: ctest --output-on-failure --test-dir build
+      run: ctest --output-on-failure --test-dir build/release
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,142 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "CMake Configure Debug",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--preset=vcpkg-debug"
+            ],
+            "problemMatcher": [],
+            "group": "build"
+        },
+        {
+            "label": "CMake Configure Release",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--preset=vcpkg-release"
+            ],
+            "problemMatcher": [],
+            "group": "build"
+        },
+        {
+            "label": "CMake Build Debug",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "${workspaceFolder}/build/debug"
+            ],
+            "problemMatcher": "$gcc",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "CMake Build Release",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "${workspaceFolder}/build/release"
+            ],
+            "problemMatcher": "$gcc",
+            "group": "build"
+        },
+        {
+            "label": "Run Tests Debug",
+            "type": "shell",
+            "command": "ctest",
+            "args": [
+                "--test-dir",
+                "${workspaceFolder}/build/debug"
+            ],
+            "dependsOn": [
+                "CMake Build Debug"
+            ],
+            "group": "test",
+            "problemMatcher": []
+        },
+        {
+            "label": "Run Tests Release",
+            "type": "shell",
+            "command": "ctest",
+            "args": [
+                "--test-dir",
+                "${workspaceFolder}/build/release"
+            ],
+            "dependsOn": [
+                "CMake Build Release"
+            ],
+            "group": "test",
+            "problemMatcher": []
+        },
+        {
+            "label": "Run Server Test Debug",
+            "type": "shell",
+            "command": "ctest",
+            "args": [
+                "--test-dir",
+                "${workspaceFolder}/build/debug",
+                "-R",
+                "server_test"
+            ],
+            "dependsOn": [
+                "CMake Build Debug"
+            ],
+            "group": "test",
+            "problemMatcher": []
+        },
+        {
+            "label": "Run Client Test Debug",
+            "type": "shell",
+            "command": "ctest",
+            "args": [
+                "--test-dir",
+                "${workspaceFolder}/build/debug",
+                "-R",
+                "client_test"
+            ],
+            "dependsOn": [
+                "CMake Build Debug"
+            ],
+            "group": "test",
+            "problemMatcher": []
+        },
+        {
+            "label": "Run Server Test Release",
+            "type": "shell",
+            "command": "ctest",
+            "args": [
+                "--test-dir",
+                "${workspaceFolder}/build/release",
+                "-R",
+                "server_test"
+            ],
+            "dependsOn": [
+                "CMake Build Release"
+            ],
+            "group": "test",
+            "problemMatcher": []
+        },
+        {
+            "label": "Run Client Test Release",
+            "type": "shell",
+            "command": "ctest",
+            "args": [
+                "--test-dir",
+                "${workspaceFolder}/build/release",
+                "-R",
+                "client_test"
+            ],
+            "dependsOn": [
+                "CMake Build Release"
+            ],
+            "group": "test",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,26 +30,15 @@ add_library(
   ${PROJECT_SOURCE_DIR}/server.cpp
 )
 
-add_library(
-  client
-  ${PROJECT_SOURCE_DIR}/client.cpp
-)
-
 add_executable(
   server_test
   ${PROJECT_SOURCE_DIR}/server_test.cpp
-)
-add_executable(
-  client_test
-  ${PROJECT_SOURCE_DIR}/client_test.cpp
 )
 
 set(COMMON_LIBS Botan::Botan-static nlohmann_json::nlohmann_json)
 
 target_link_libraries(server PRIVATE ${COMMON_LIBS})
-target_link_libraries(client PRIVATE ${COMMON_LIBS})
 target_link_libraries(main PRIVATE ${COMMON_LIBS} Catch2::Catch2WithMain)
-target_link_libraries(client_test PRIVATE client ${COMMON_LIBS} Catch2::Catch2WithMain)
 target_link_libraries(server_test PRIVATE server ${COMMON_LIBS} Catch2::Catch2WithMain)
 
 
@@ -57,6 +46,4 @@ enable_testing()
 add_test(NAME server_test
   COMMAND
   $<TARGET_FILE:server_test>)
-add_test(NAME client_test
-  COMMAND
-  $<TARGET_FILE:client_test>)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.31)
 project(pbc)
 
-
 # Set the version for pbc
 set(pbc_Version_Major 0)
 set(pbc_Version_Minor 1)
@@ -12,47 +11,52 @@ set(PROJECT_VERSION
 )
 message(STATUS "${PROJECT_NAME} version: ${PROJECT_VERSION}")
 
-set(CMAKE_SOURCE_DIR src)
+set(PROJECT_SOURCE_DIR src)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_BUILD_TYPE Debug)
 
-# set(CMAKE_PREFIX_PATH /opt/homebrew/Cellar/botan/3.7.1/)
 find_package(Catch2 REQUIRED)
 find_package(botan REQUIRED)
 find_package(nlohmann_json REQUIRED)
 
-
-
 add_executable(
   main
-  ${CMAKE_SOURCE_DIR}/main.cpp
+  ${PROJECT_SOURCE_DIR}/main.cpp
 )
 
 add_library(
   server
-  ${CMAKE_SOURCE_DIR}/server.cpp
+  ${PROJECT_SOURCE_DIR}/server.cpp
+)
+
+add_library(
+  client
+  ${PROJECT_SOURCE_DIR}/client.cpp
 )
 
 add_executable(
   server_test
-  ${CMAKE_SOURCE_DIR}/server_test.cpp
+  ${PROJECT_SOURCE_DIR}/server_test.cpp
 )
-# target_include_directories(main PUBLIC /opt/homebrew/Cellar/botan)
-# link_directories(/opt/homebrew/Cellar/botan/3.7.1/)
-target_link_libraries(server PRIVATE Botan::Botan-static
-  nlohmann_json::nlohmann_json)
-target_link_libraries( main PRIVATE Botan::Botan-static
-  Catch2::Catch2WithMain)
-target_link_libraries(server_test
-  PRIVATE server
-  Botan::Botan-static
-  Catch2::Catch2WithMain
-  nlohmann_json::nlohmann_json)
+add_executable(
+  client_test
+  ${PROJECT_SOURCE_DIR}/client_test.cpp
+)
+
+set(COMMON_LIBS Botan::Botan-static nlohmann_json::nlohmann_json)
+
+target_link_libraries(server PRIVATE ${COMMON_LIBS})
+target_link_libraries(client PRIVATE ${COMMON_LIBS})
+target_link_libraries(main PRIVATE ${COMMON_LIBS} Catch2::Catch2WithMain)
+target_link_libraries(client_test PRIVATE client ${COMMON_LIBS} Catch2::Catch2WithMain)
+target_link_libraries(server_test PRIVATE server ${COMMON_LIBS} Catch2::Catch2WithMain)
 
 
 enable_testing()
 add_test(NAME server_test
   COMMAND
   $<TARGET_FILE:server_test>)
+add_test(NAME client_test
+  COMMAND
+  $<TARGET_FILE:client_test>)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,22 +1,37 @@
 {
-  "version": 2,
+  "version": 3,
   "configurePresets": [
     {
-      "name": "vcpkg",
+      "name": "vcpkg-debug",
       "generator": "Ninja",
-      "binaryDir": "build",
+      "binaryDir": "${sourceDir}/build/debug",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
         "CMAKE_BUILD_TYPE": "Debug"
       }
+    },
+    {
+      "name": "vcpkg-release",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     }
   ],
   "buildPresets": [
     {
-      "name": "default",
-      "displayName": "Default",
-      "configurePreset": "vcpkg"
+      "name": "debug",
+      "displayName": "Debug Build",
+      "configurePreset": "vcpkg-debug"
+    },
+    {
+      "name": "release",
+      "displayName": "Release Build",
+      "configurePreset": "vcpkg-release"
     }
   ]
 }


### PR DESCRIPTION
This pull request includes several changes to streamline the CMake configuration and build process, as well as to improve the organization of the project. The most important changes include updates to the GitHub Actions workflow, the addition of new tasks in VS Code, and modifications to the CMake configuration files.

### GitHub Actions Workflow:
* Updated the `configurePreset` and `buildPreset` values in the `cmake-single-platform.yml` workflow to use `vcpkg-release` and `release` respectively.
* Changed the `ctest` command to point to the `build/release` directory.

### VS Code Tasks:
* Added new tasks in `.vscode/tasks.json` for configuring and building both debug and release versions, as well as running tests for both versions.

### CMake Configuration:
* Updated `CMakeLists.txt` to replace `CMAKE_SOURCE_DIR` with `PROJECT_SOURCE_DIR` and added new targets for `client` and `client_test`. Also, consolidated common libraries into a `COMMON_LIBS` variable.
* Updated `CMakePresets.json` to include separate presets for debug (`vcpkg-debug`) and release (`vcpkg-release`) configurations.